### PR TITLE
fix(#4): dovecot_time grok pattern

### DIFF
--- a/mailcow-content-pack.json
+++ b/mailcow-content-pack.json
@@ -2188,7 +2188,7 @@
       "id": "f2647393-867e-4399-bf77-10f309be44c3",
       "data": {
         "name": "DOVECOT_TIME",
-        "pattern": "%{WORD} %{NUMBER} %{TIME}"
+        "pattern": "%{WORD}%{SPACE}%{NUMBER} %{TIME}"
       },
       "constraints": [
         {


### PR DESCRIPTION
This fixes the dovecot_time grok pattern for dovecot fields extraction.

See https://github.com/ntimo/graylog-mailcow-content-pack/issues/4#issuecomment-576012714